### PR TITLE
Implement HUD health bars for player and enemy

### DIFF
--- a/Health.cs
+++ b/Health.cs
@@ -6,28 +6,38 @@ public class Health : MonoBehaviour, IDamageable
 {
     [SerializeField] private int maxHealth = 3;
     public int CurrentHealth { get; private set; }
+    public int MaxHealth => maxHealth;
     public event Action OnDeath;
+    // Event that notifies listeners when health changes; provides current and max values
+    public event Action<int, int> OnHealthChanged;
 
     private void Awake()
     {
         CurrentHealth = maxHealth;
+        // Invoke initial health state
+        OnHealthChanged?.Invoke(CurrentHealth, maxHealth);
     }
 
     public void TakeDamage(int amount, Vector2 hitPoint, Vector2 hitNormal)
     {
         if (CurrentHealth <= 0) return;
         CurrentHealth -= amount;
+        // Notify listeners of health change
+        OnHealthChanged?.Invoke(CurrentHealth, maxHealth);
         if (CurrentHealth <= 0) Die();
     }
 
     public void Heal(int amount)
     {
         CurrentHealth = Mathf.Min(CurrentHealth + amount, maxHealth);
+        OnHealthChanged?.Invoke(CurrentHealth, maxHealth);
     }
 
     private void Die()
     {
         OnDeath?.Invoke();
+        // Ensure UI reflects zero health
+        OnHealthChanged?.Invoke(CurrentHealth, maxHealth);
         Destroy(gameObject);
     }
 }

--- a/HealthBarUI.cs
+++ b/HealthBarUI.cs
@@ -1,0 +1,65 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+// HealthBarUI updates a UI Image to reflect the health of a target entity.
+// It listens for health change and death events from the Health component and updates the bar accordingly.
+public class HealthBarUI : MonoBehaviour
+{
+    [Tooltip("Health component to monitor")] 
+    [SerializeField] private Health targetHealth;
+
+    [Tooltip("Image component used to display the fill amount of the health bar")] 
+    [SerializeField] private Image healthFillImage;
+
+    private void OnEnable()
+    {
+        if (targetHealth != null)
+        {
+            // Subscribe to health change and death events
+            targetHealth.OnHealthChanged += HandleHealthChanged;
+            targetHealth.OnDeath += HandleDeath;
+        }
+    }
+
+    private void Start()
+    {
+        // Initialize bar with current health at start
+        if (targetHealth != null)
+        {
+            UpdateBar(targetHealth.CurrentHealth, targetHealth.MaxHealth);
+        }
+    }
+
+    private void OnDisable()
+    {
+        if (targetHealth != null)
+        {
+            // Unsubscribe from events to avoid memory leaks
+            targetHealth.OnHealthChanged -= HandleHealthChanged;
+            targetHealth.OnDeath -= HandleDeath;
+        }
+    }
+
+    // Event handler invoked when health changes
+    private void HandleHealthChanged(int current, int max)
+    {
+        UpdateBar(current, max);
+    }
+
+    // Event handler invoked when the target dies
+    private void HandleDeath()
+    {
+        // Optionally hide the health bar upon death
+        gameObject.SetActive(false);
+    }
+
+    // Updates the fill amount of the UI image
+    private void UpdateBar(int current, int max)
+    {
+        if (healthFillImage != null)
+        {
+            float fill = max > 0 ? (float)current / max : 0f;
+            healthFillImage.fillAmount = fill;
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces an event-driven health bar system for both player and enemy.

- **Health.cs**: added `MaxHealth` property, `OnHealthChanged` event, and invocation of the event on initialization, damage, healing, and death.
- **HealthBarUI.cs**: new component that binds UI Image to a `Health` component, updating the bar on health changes and hiding it on death.

These changes allow adaptive HUD bars without polling, following the event-driven design.